### PR TITLE
Bump Version 0.3.0

### DIFF
--- a/CASE-Bindings-CSharp-Monitor.csproj
+++ b/CASE-Bindings-CSharp-Monitor.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="CipherTech.CASE.Bindings" Version="0.2.0" />
+    <PackageReference Include="CipherTech.CASE.Bindings" Version="0.3.0" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
- Update the dependency to the 0.3.0 version of [CipherTech.CASE.Bindings](https://www.nuget.org/packages/CipherTech.CASE.Bindings) to support CASE 1.1.0