### PR TITLE
Update to Support CASE 1.2.0

### DIFF
--- a/.github/workflows/monitor.yml
+++ b/.github/workflows/monitor.yml
@@ -40,10 +40,10 @@ jobs:
       - name: Build
         run: bin/Release/**/publish/CASE-Bindings-CSharp-Monitor
 
-      # Run the CASE validation job to confirm the output is valid. Note, this is pinned to CASE 1.0.0 as the CASE Bindings project supports 1.0.0
+      # Run the CASE validation job to confirm the output is valid
       - name: CASE Export Validation
-        uses: kchason/case-validation-action@v2.5
+        uses: kchason/case-validation-action@v2.6
         with:
           case-path: case.json
-          case-version: "case-1.1.0"
+          case-version: "case-1.2.0"
       

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# IDE Artifacts
+/.vscode
+
 # .NET artifacts
 /obj
 /bin

--- a/CASE-Bindings-CSharp-Monitor.csproj
+++ b/CASE-Bindings-CSharp-Monitor.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="CipherTech.CASE.Bindings" Version="0.3.0" />
+    <PackageReference Include="CipherTech.CASE.Bindings" Version="0.4.0" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
- Update to CASE Bindings 0.4.0 (https://www.nuget.org/packages/CipherTech.CASE.Bindings/)
- Update to CASE Validator v2.6 (https://github.com/marketplace/actions/case-ontology-validator)